### PR TITLE
Add missing @types/node package

### DIFF
--- a/feeder/package.json
+++ b/feeder/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.33",
+    "@types/node": "^15.12.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "eslint": "^7.18.0",


### PR DESCRIPTION
Other it throws this error

```
Error: Cannot find module '@types/node/package.json'
Require stack:
- /home/ti/workspace/oracle-feeder/feeder/node_modules/ts-node/dist/index.js
- /home/ti/workspace/oracle-feeder/feeder/node_modules/ts-node/dist/repl.js
- /home/ti/workspace/oracle-feeder/feeder/node_modules/ts-node/dist/bin.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:623:15)
    at Function.resolve (internal/modules/cjs/helpers.js:21:19)
    at /home/ti/workspace/oracle-feeder/feeder/node_modules/ts-node/src/index.ts:746:52
    at Array.map (<anonymous>)
    at Object.resolveTypeReferenceDirectives (/home/ti/workspace/oracle-feeder/feeder/node_modules/ts-node/src/index.ts:734:33)
    at actualResolveTypeReferenceDirectiveNamesWorker (/home/ti/workspace/oracle-feeder/feeder/node_modules/typescript/lib/typescript.js:109509:143)
    at resolveTypeReferenceDirectiveNamesWorker (/home/ti/workspace/oracle-feeder/feeder/node_modules/typescript/lib/typescript.js:109768:26)
    at processTypeReferenceDirectives (/home/ti/workspace/oracle-feeder/feeder/node_modules/typescript/lib/typescript.js:111218:31)
    at findSourceFileWorker (/home/ti/workspace/oracle-feeder/feeder/node_modules/typescript/lib/typescript.js:111102:21)
    at findSourceFile (/home/ti/workspace/oracle-feeder/feeder/node_modules/typescript/lib/typescript.js:110969:26)
```
