### PR TITLE
price-server: Add Prometheus support

### DIFF
--- a/price-server/config/default-sample.js
+++ b/price-server/config/default-sample.js
@@ -20,6 +20,7 @@ const fiatSymbols = [
 
 module.exports = {
   port: 8532,
+  metricsPort: 8533,
   sentry: '', // sentry dsn (https://sentry.io/ - error reporting service)
   slack: {
     // for incident alarm (e.g. exchange shutdown)

--- a/price-server/package-lock.json
+++ b/price-server/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.4.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/exporter-prometheus": "^0.23.0",
+        "@opentelemetry/metrics": "^0.23.0",
         "@polka/send-type": "^0.5.2",
         "@sentry/node": "^6.0.2",
         "bignumber.js": "^9.0.1",
@@ -1036,6 +1038,97 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
+      "integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-metrics": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.23.0.tgz",
+      "integrity": "sha512-MGfH9aMnVktRTagYHvhksrk42vPDjTIz5N6Cxu31t6dgJa6iUYR6MemnOdphyLk73DUaqmR5s2Fn6jg0Xd9gqA==",
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
+      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "0.23.0",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.23.0.tgz",
+      "integrity": "sha512-1CIiGzLO6bRYqnEoDhDEy2ucxPNQW+DHQvTg4bb8ZEv/67aSRzssVtFnQkke46n3ndZLyVlqjcYc/nHeXdgZZA==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.23.0",
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/metrics": "0.23.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/metrics": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.23.0.tgz",
+      "integrity": "sha512-IRl/AfnNFmmNZrM58R2T/gVqatPve+T2EpaBbWv4zVfY9Q2S8q7oT8HZAPUc/GQTb2pvwLXpcKO8QmeEt4gfHQ==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.23.0",
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/resources": "0.23.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
+      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
+      "dependencies": {
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/semantic-conventions": "0.23.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
+      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@polka/send-type": {
@@ -5021,8 +5114,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -5104,7 +5196,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6596,7 +6687,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7973,8 +8063,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -8830,6 +8919,62 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@opentelemetry/api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.1.tgz",
+      "integrity": "sha512-H5Djcc2txGAINgf3TNaq4yFofYSIK3722PM89S/3R8FuI/eqi1UscajlXk7EBkG9s2pxss/q6SHlpturaavXaw==",
+      "peer": true
+    },
+    "@opentelemetry/api-metrics": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.23.0.tgz",
+      "integrity": "sha512-MGfH9aMnVktRTagYHvhksrk42vPDjTIz5N6Cxu31t6dgJa6iUYR6MemnOdphyLk73DUaqmR5s2Fn6jg0Xd9gqA==",
+      "requires": {}
+    },
+    "@opentelemetry/core": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.23.0.tgz",
+      "integrity": "sha512-7COVsnGEW96ITjc0waWYo/R27sFqjPUg4SCoP8XL48zAGr9zjzeuJoQe/xVchs7op//qOeeEEeBxiBvXy2QS0Q==",
+      "requires": {
+        "@opentelemetry/semantic-conventions": "0.23.0",
+        "semver": "^7.1.3"
+      }
+    },
+    "@opentelemetry/exporter-prometheus": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.23.0.tgz",
+      "integrity": "sha512-1CIiGzLO6bRYqnEoDhDEy2ucxPNQW+DHQvTg4bb8ZEv/67aSRzssVtFnQkke46n3ndZLyVlqjcYc/nHeXdgZZA==",
+      "requires": {
+        "@opentelemetry/api-metrics": "0.23.0",
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/metrics": "0.23.0"
+      }
+    },
+    "@opentelemetry/metrics": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/metrics/-/metrics-0.23.0.tgz",
+      "integrity": "sha512-IRl/AfnNFmmNZrM58R2T/gVqatPve+T2EpaBbWv4zVfY9Q2S8q7oT8HZAPUc/GQTb2pvwLXpcKO8QmeEt4gfHQ==",
+      "requires": {
+        "@opentelemetry/api-metrics": "0.23.0",
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/resources": "0.23.0",
+        "lodash.merge": "^4.6.2"
+      }
+    },
+    "@opentelemetry/resources": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.23.0.tgz",
+      "integrity": "sha512-sAiaoQ0pOwjaaKySuwCUlvej/W9M5d+SxpcuBFUBUojqRlEAYDbx1FHClPnKtOysIb9rXJDQvM3xlH++7NQQzg==",
+      "requires": {
+        "@opentelemetry/core": "0.23.0",
+        "@opentelemetry/semantic-conventions": "0.23.0"
+      }
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.23.0.tgz",
+      "integrity": "sha512-Tzo+VGR1zlzLbjVI+7mlDJ2xuaUsue4scWvFlK+fzcUfn9siF4NWbxoC2X6Br2B/g4dsq1OAwAYsPVYIEoY2rQ=="
     },
     "@polka/send-type": {
       "version": "0.5.2",
@@ -11900,8 +12045,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.truncate": {
       "version": "4.4.2",
@@ -11964,7 +12108,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -13092,7 +13235,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -14181,8 +14323,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/price-server/package.json
+++ b/price-server/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint '*/**/*.{js,ts,tsx}' --fix"
   },
   "dependencies": {
+    "@opentelemetry/exporter-prometheus": "^0.23.0",
+    "@opentelemetry/metrics": "^0.23.0",
     "@polka/send-type": "^0.5.2",
     "@sentry/node": "^6.0.2",
     "bignumber.js": "^9.0.1",

--- a/price-server/src/lib/metrics.ts
+++ b/price-server/src/lib/metrics.ts
@@ -1,0 +1,62 @@
+import { Counter, UpDownCounter } from '@opentelemetry/api-metrics'
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus'
+import { Meter, MeterProvider } from '@opentelemetry/metrics'
+import * as config from 'config'
+
+let meterProvider = new MeterProvider()
+
+export async function setupMetricsServer() {
+  if (!config.metricsPort) return
+  const exporter = new PrometheusExporter({
+    preventServerStart: true,
+    port: config.metricsPort,
+  })
+  meterProvider = new MeterProvider({
+    exporter,
+    interval: 3000,
+  })
+  await exporter.startServer()
+}
+
+export let meter: Meter
+let requestCount: Counter
+const quoterAlive = new Map()
+
+function setupMetrics() {
+  if (meter) return
+  meter = meterProvider.getMeter('terra-oracle-feeder')
+  requestCount = meter.createCounter('requests', {
+    description: 'Count all incoming requests',
+  })
+  meter.createUpDownSumObserver(
+    'terra_oracle_up',
+    {
+      description: '1 if price-server quoter is up, or 0 is failed',
+    },
+    async (observerResult) => {
+      for (const [name, isAlive] of quoterAlive) {
+        observerResult.observe(isAlive ? 1 : 0, { oracle_source: name })
+      }
+    }
+  )
+}
+
+const boundInstruments = new Map()
+
+export const countAllRequests = () => {
+  setupMetrics()
+  return (req, res, next) => {
+    if (!boundInstruments.has(req.path)) {
+      const labels = { route: req.path }
+      const boundCounter = requestCount.bind(labels)
+      boundInstruments.set(req.path, boundCounter)
+    }
+    boundInstruments.get(req.path).add(1)
+    next()
+  }
+}
+
+export function setQuoterAlive(name: string, isAlive: boolean) {
+  setupMetrics()
+  quoterAlive.set(name, isAlive)
+}

--- a/price-server/src/main.ts
+++ b/price-server/src/main.ts
@@ -7,6 +7,7 @@ import { init as initErrorHandler, errorHandler } from 'lib/error'
 import { initialize as initializeProviders, tick } from 'provider'
 import { createServer } from './server'
 import * as defaultConfig from '../config/default-sample'
+import { setupMetricsServer } from 'lib/metrics'
 
 bluebird.config({ longStackTraces: true })
 global.Promise = bluebird
@@ -63,6 +64,7 @@ async function main(): Promise<void> {
   initErrorHandler({ sentry: config.sentry })
 
   await convertOldConfig()
+  await setupMetricsServer()
   await initializeProviders()
   await createServer()
 

--- a/price-server/src/provider/base/Quoter.ts
+++ b/price-server/src/provider/base/Quoter.ts
@@ -3,6 +3,7 @@ import * as logger from 'lib/logger'
 import { sendSlack } from 'lib/slack'
 import { TradesBySymbol, Trades, PriceBySymbol } from './types'
 import { format } from 'date-fns'
+import { setQuoterAlive } from 'lib/metrics'
 
 export interface QuoterOptions {
   symbols: string[] // support symbols
@@ -178,6 +179,7 @@ export class Quoter {
 
       this.isAlive = false
     }
+    setQuoterAlive(this.constructor.name, this.isAlive)
   }
 
   printTrades(symbol: string): void {

--- a/price-server/src/server.ts
+++ b/price-server/src/server.ts
@@ -6,12 +6,15 @@ import * as config from 'config'
 import * as logger from 'lib/logger'
 import { getQuoteCurrency } from 'lib/currency'
 import { getLunaPrices } from 'prices'
+import { countAllRequests } from 'lib/metrics'
 
 bluebird.config({ longStackTraces: true })
 global.Promise = bluebird
 
 export async function createServer(): Promise<http.Server> {
   const app = polka({})
+
+  app.use(countAllRequests())
 
   app.get('/health', (req, res) => {
     res.end('OK')


### PR DESCRIPTION
Adds Prometheus support to `price-server` using OpenTelemetry with the following metrics:
- `terra_oracle_up` to report whether an oracle source is up. This closes #35, since alerts on oracle failures can now be raised by the powerful Prometheus alerting functionality.
- `requests_total` to report request count.

The metrics server is going to listen on `http://localhost:8533/metrics` by default.
Example response:

```
# HELP terra_oracle_up 1 if price-server quoter is up, or 0 is failed
# TYPE terra_oracle_up gauge
terra_oracle_up{oracle_source="ExchangeRate"} 1 1627320558088
terra_oracle_up{oracle_source="BandProtocol"} 1 1627320558088
terra_oracle_up{oracle_source="Bitfinex"} 1 1627320558088
terra_oracle_up{oracle_source="Kraken"} 1 1627320558088
terra_oracle_up{oracle_source="Huobi"} 1 1627320558088
terra_oracle_up{oracle_source="Binance"} 1 1627320558088
terra_oracle_up{oracle_source="Kucoin"} 1 1627320558088
# HELP requests_total Count all incoming requests
# TYPE requests_total counter
requests_total{route="/health"} 4 1627320551613
requests_total{route="/latest"} 1 1627320555879
```