### PR TITLE
Do not override slack username

### DIFF
--- a/price-server/src/lib/slack.ts
+++ b/price-server/src/lib/slack.ts
@@ -11,7 +11,6 @@ export function sendSlack(message: string): Promise<Response | void> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       channel: config.get('slack.channel'),
-      username: 'Oracle PriceServer',
       text: message,
     }),
   })


### PR DESCRIPTION
Use the webhook integration username instead of overriding it.
This allows operators to make a difference between different running price servers (ex: mainnet/testnet) alerts by using one webhook integration per price-server