### PR TITLE
Adding ZAR support - help needed

### DIFF
--- a/price-server/README.md
+++ b/price-server/README.md
@@ -51,6 +51,7 @@ const fiatSymbols = [
   'USD/DKK',
   'USD/IDR',
   'USD/PHP',
+  'USD/ZAR',
 ]
 
 module.exports = {

--- a/price-server/config/default-sample.js
+++ b/price-server/config/default-sample.js
@@ -18,6 +18,7 @@ const fiatSymbols = [
   'USD/DKK',
   'USD/IDR',
   'USD/PHP',
+  'USD/ZAR',
 ]
 
 module.exports = {
@@ -52,7 +53,7 @@ module.exports = {
     },
     bandprotocol: {
       // DKK is not supported for bandprotocol
-      symbols: fiatSymbols.filter(v => !v.includes('DKK') && !v.includes('PHP')),
+      symbols: fiatSymbols.filter(v => !v.includes('DKK') && !v.includes('PHP') && !v.includes('ZAR')),
       interval: 60 * 1000,
       timeout: 5000,
       // https://data.bandprotocol.com/


### PR DESCRIPTION
I'm trying to figure out what's all required to add South African Rand (ZAR) support to Terra. Want to help grow the ecosystem in Southern Africa and Rand support would be super useful.

Not sure what else is required to get the token whitelisted and nodes to supply feeds.

https://docs.terra.money/Reference/Terra-core/Module-specifications/spec-oracle.html#oracle

The feeds seem to work fine with the default set of API providers.

![image](https://user-images.githubusercontent.com/315252/142359952-20da0625-f515-4c0e-a4a5-f9b84d57f009.png)
