### PR TITLE
Enforce HTTPS channel while fetching prices

### DIFF
--- a/price-server/src/provider/fiat/quoter/Fixer.ts
+++ b/price-server/src/provider/fiat/quoter/Fixer.ts
@@ -23,7 +23,7 @@ export class Fixer extends Quoter {
     }
 
     const response: Response = await fetch(
-      `http://data.fixer.io/api/latest?${toQueryString(params)}`,
+      `https://data.fixer.io/api/latest?${toQueryString(params)}`,
       { timeout: this.options.timeout }
     ).then((res) => res.json())
 


### PR DESCRIPTION
enforce https rather than rely on 302 in the upstream web server.